### PR TITLE
Add editing and primitive tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # 3DModelling
+
+This project is a starting point for building a 3D modelling website using [Babylon.js](https://www.babylonjs.com/).
+
+## Getting Started
+Simply open `index.html` in a modern web browser. The page loads Babylon.js from a CDN and displays a rotating cube that you can inspect using mouse controls.
+
+Click any mesh to change its colour. A sphere orbits around the cube above a simple ground plane.
+
+Press **Tab** to switch between **Object Mode** and **Edit Mode**. In edit mode small spheres appear at the cube's vertices allowing you to drag them and modify the shape.
+
+While in object mode you can add primitives using the keyboard:
+
+- **1** – add a box
+- **2** – add a sphere
+- **3** – add a cylinder

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>3D Modelling</title>
+  <style>
+    html, body { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; }
+    #renderCanvas { width: 100%; height: 100%; touch-action: none; }
+    #modeIndicator {
+      position: absolute;
+      top: 5px;
+      left: 5px;
+      background: rgba(0,0,0,0.5);
+      color: white;
+      padding: 4px 8px;
+      font-family: sans-serif;
+      z-index: 1;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="renderCanvas"></canvas>
+  <div id="modeIndicator">Object Mode</div>
+  <script src="https://cdn.babylonjs.com/babylon.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,144 @@
+window.addEventListener('DOMContentLoaded', function () {
+  const canvas = document.getElementById('renderCanvas');
+  const modeIndicator = document.getElementById('modeIndicator');
+  const engine = new BABYLON.Engine(canvas, true);
+
+  const createScene = function () {
+    const scene = new BABYLON.Scene(engine);
+
+    const camera = new BABYLON.ArcRotateCamera(
+      'camera',
+      -Math.PI / 2,
+      Math.PI / 2.5,
+      5,
+      BABYLON.Vector3.Zero(),
+      scene,
+    );
+    camera.attachControl(canvas, true);
+
+    const light = new BABYLON.HemisphericLight(
+      'light',
+      new BABYLON.Vector3(0, 1, 0),
+      scene,
+    );
+
+    const box = BABYLON.MeshBuilder.CreateBox('box', { size: 1, updatable: true });
+    box.position.y = 0.5;
+    const ground = BABYLON.MeshBuilder.CreateGround(
+      'ground',
+      { width: 6, height: 6 },
+      scene,
+    );
+    const sphere = BABYLON.MeshBuilder.CreateSphere('sphere', { diameter: 0.75 });
+    sphere.position.y = 1.5;
+
+    let editMode = false;
+    const vertexSpheres = [];
+
+    function getVertexGroups(mesh) {
+      const positions = mesh.getVerticesData(BABYLON.VertexBuffer.PositionKind);
+      const groups = [];
+      for (let i = 0; i < positions.length; i += 3) {
+        const p = new BABYLON.Vector3(positions[i], positions[i + 1], positions[i + 2]);
+        let found = groups.find(g => g.pos.equalsWithEpsilon(p));
+        if (!found) {
+          found = { pos: p.clone(), indices: [] };
+          groups.push(found);
+        }
+        found.indices.push(i);
+      }
+      return groups;
+    }
+
+    function createVertexSpheres(mesh) {
+      const groups = getVertexGroups(mesh);
+      groups.forEach(g => {
+        const vs = BABYLON.MeshBuilder.CreateSphere('v', { diameter: 0.1 }, scene);
+        vs.position.copyFrom(g.pos);
+        vs.isVisible = false;
+        const drag = new BABYLON.PointerDragBehavior();
+        drag.useObjectOrientationForDragging = false;
+        vs.addBehavior(drag);
+        drag.onDragObservable.add(ev => {
+          g.pos.copyFrom(ev.dragPlanePoint);
+          vs.position.copyFrom(g.pos);
+          const positions = mesh.getVerticesData(BABYLON.VertexBuffer.PositionKind);
+          g.indices.forEach(idx => {
+            positions[idx] = g.pos.x;
+            positions[idx + 1] = g.pos.y;
+            positions[idx + 2] = g.pos.z;
+          });
+          mesh.updateVerticesData(BABYLON.VertexBuffer.PositionKind, positions);
+        });
+        vertexSpheres.push(vs);
+      });
+    }
+
+    createVertexSpheres(box);
+
+    function setMode(isEdit) {
+      editMode = isEdit;
+      modeIndicator.textContent = editMode ? 'Edit Mode' : 'Object Mode';
+      vertexSpheres.forEach(s => (s.isVisible = editMode));
+    }
+
+    function addPrimitive(key) {
+      switch (key) {
+        case '1':
+          BABYLON.MeshBuilder.CreateBox('box' + Date.now(), { size: 1 }, scene).position.y = 0.5;
+          break;
+        case '2':
+          BABYLON.MeshBuilder.CreateSphere('sphere' + Date.now(), { diameter: 1 }, scene).position.y = 0.5;
+          break;
+        case '3':
+          BABYLON.MeshBuilder.CreateCylinder('cyl' + Date.now(), { height: 1, diameter: 1 }, scene).position.y = 0.5;
+          break;
+      }
+    }
+
+    window.addEventListener('keydown', e => {
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        setMode(!editMode);
+      } else if (!editMode) {
+        addPrimitive(e.key);
+      }
+    });
+
+    let angle = 0;
+    scene.registerBeforeRender(function () {
+      box.rotation.y += 0.01;
+      angle += 0.02;
+      sphere.position.x = Math.cos(angle) * 2;
+      sphere.position.z = Math.sin(angle) * 2;
+    });
+
+    scene.onPointerObservable.add(pointerInfo => {
+      if (pointerInfo.type === BABYLON.PointerEventTypes.POINTERPICK) {
+        const mesh = pointerInfo.pickInfo && pointerInfo.pickInfo.pickedMesh;
+        if (mesh) {
+          const mat =
+            mesh.material || new BABYLON.StandardMaterial('mat', scene);
+          mesh.material = mat;
+          mat.diffuseColor = new BABYLON.Color3(
+            Math.random(),
+            Math.random(),
+            Math.random(),
+          );
+        }
+      }
+    });
+
+    return scene;
+  };
+
+  const scene = createScene();
+
+  engine.runRenderLoop(function () {
+    scene.render();
+  });
+
+  window.addEventListener('resize', function () {
+    engine.resize();
+  });
+});


### PR DESCRIPTION
## Summary
- add mode indicator overlay to HTML
- implement object and edit modes with Tab key
- allow vertex editing on the default cube
- enable adding primitive meshes via number keys
- update README with new controls

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6882bdd12c048328bb293df60697f311